### PR TITLE
Add CLI translator (stdin + postprocess)

### DIFF
--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -837,26 +837,26 @@ class CLISettings(BaseModel):
     Input text is always passed via stdin.
 
     Example (stdin, default):
-    - cli_command: "your-translator-command --flag value"
+    - clitranslator_command: "your-translator-command --flag value"
     """
 
-    translate_engine_type: Literal["CLI"] = Field(default="CLI")
+    translate_engine_type: Literal["CLITranslator"] = Field(default="CLITranslator")
     support_llm: Literal["yes", "no"] = Field(default="no")
 
-    cli_command: str = Field(
+    clitranslator_command: str = Field(
         default="",
         description=(
             "CLI command to execute. May include arguments and will be split like a "
             "shell command (e.g., 'your-translator-command --flag value')."
         ),
     )
-    cli_timeout: int = Field(
+    clitranslator_timeout: int = Field(
         default=60,
         description="Command timeout in seconds",
         ge=1,
         le=300,
     )
-    cli_postprocess_command: str | None = Field(
+    clitranslator_postprocess_command: str | None = Field(
         default=None,
         description=(
             "Optional postprocess command to run on CLI output (reads from stdin). "
@@ -865,36 +865,43 @@ class CLISettings(BaseModel):
     )
 
     def validate_settings(self):
-        if not self.cli_command:
-            raise ValueError("CLI command is required. Please specify --cli-command")
+        if not self.clitranslator_command:
+            raise ValueError(
+                "CLI command is required. Please specify --clitranslator-command"
+            )
 
         try:
-            command_parts = shlex.split(self.cli_command)
+            command_parts = shlex.split(self.clitranslator_command)
         except ValueError as e:
-            raise ValueError(f"Invalid cli_command: {e}") from e
+            raise ValueError(f"Invalid clitranslator_command: {e}") from e
         if not command_parts:
-            raise ValueError("CLI command is required. Please specify --cli-command")
+            raise ValueError(
+                "CLI command is required. Please specify --clitranslator-command"
+            )
 
         forbidden_templates = ("{text}", "{lang_in}", "{lang_out}")
-        if any(token in self.cli_command for token in forbidden_templates):
+        if any(token in self.clitranslator_command for token in forbidden_templates):
             raise ValueError(
                 "Template variables are not supported. "
-                "Pass fixed arguments in cli_command and provide input via stdin."
+                "Pass fixed arguments in clitranslator_command and provide input via stdin."
             )
-        if self.cli_postprocess_command is not None:
-            if not self.cli_postprocess_command.strip():
-                raise ValueError("cli_postprocess_command cannot be empty")
+        if self.clitranslator_postprocess_command is not None:
+            if not self.clitranslator_postprocess_command.strip():
+                raise ValueError("clitranslator_postprocess_command cannot be empty")
             try:
-                postprocess_parts = shlex.split(self.cli_postprocess_command)
+                postprocess_parts = shlex.split(self.clitranslator_postprocess_command)
             except ValueError as e:
-                raise ValueError(f"Invalid cli_postprocess_command: {e}") from e
+                raise ValueError(
+                    f"Invalid clitranslator_postprocess_command: {e}"
+                ) from e
             if not postprocess_parts:
-                raise ValueError("cli_postprocess_command cannot be empty")
+                raise ValueError("clitranslator_postprocess_command cannot be empty")
             if any(
-                token in self.cli_postprocess_command for token in forbidden_templates
+                token in self.clitranslator_postprocess_command
+                for token in forbidden_templates
             ):
                 raise ValueError(
-                    "Template variables are not supported in cli_postprocess_command."
+                    "Template variables are not supported in clitranslator_postprocess_command."
                 )
 
 

--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -836,8 +836,8 @@ class CLISettings(BaseModel):
 
     Input text is always passed via stdin.
 
-    Example for plamo-translate (stdin, default):
-    - cli_command: "uvx plamo-translate"
+    Example (stdin, default):
+    - cli_command: "your-translator-command --flag value"
     """
 
     translate_engine_type: Literal["CLI"] = Field(default="CLI")
@@ -847,7 +847,7 @@ class CLISettings(BaseModel):
         default="",
         description=(
             "CLI command to execute. May include arguments and will be split like a "
-            "shell command (e.g., 'uvx plamo-translate --flag value')."
+            "shell command (e.g., 'your-translator-command --flag value')."
         ),
     )
     cli_timeout: int = Field(

--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -856,19 +856,11 @@ class CLISettings(BaseModel):
         ge=1,
         le=300,
     )
-    cli_output_format: Literal["plain", "json"] = Field(
-        default="plain",
-        description="Output format: 'plain' for raw text, 'json' for JSON response",
-    )
-    cli_json_path: str | None = Field(
-        default=None,
-        description="JSON path to extract translation (e.g., 'result.translation')",
-    )
     cli_postprocess_command: str | None = Field(
         default=None,
         description=(
             "Optional postprocess command to run on CLI output (reads from stdin). "
-            "Example: 'jq -r .result.translation'"
+            "Example: 'jq -r .result.translation' or 'jq -r .reqult.translation'"
         ),
     )
 
@@ -904,9 +896,6 @@ class CLISettings(BaseModel):
                 raise ValueError(
                     "Template variables are not supported in cli_postprocess_command."
                 )
-
-        if self.cli_output_format == "json" and not self.cli_json_path:
-            raise ValueError("cli_json_path is required when cli_output_format='json'")
 
 
 ## Please add the translator configuration class above this location.

--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -860,7 +860,7 @@ class CLISettings(BaseModel):
         default=None,
         description=(
             "Optional postprocess command to run on CLI output (reads from stdin). "
-            "Example: 'jq -r .result.translation' or 'jq -r .reqult.translation'"
+            "Example: 'jq -r .result.translation'"
         ),
     )
 

--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -879,12 +879,6 @@ class CLISettings(BaseModel):
                 "CLI command is required. Please specify --clitranslator-command"
             )
 
-        forbidden_templates = ("{text}", "{lang_in}", "{lang_out}")
-        if any(token in self.clitranslator_command for token in forbidden_templates):
-            raise ValueError(
-                "Template variables are not supported. "
-                "Pass fixed arguments in clitranslator_command and provide input via stdin."
-            )
         if self.clitranslator_postprocess_command is not None:
             if not self.clitranslator_postprocess_command.strip():
                 raise ValueError("clitranslator_postprocess_command cannot be empty")
@@ -896,13 +890,6 @@ class CLISettings(BaseModel):
                 ) from e
             if not postprocess_parts:
                 raise ValueError("clitranslator_postprocess_command cannot be empty")
-            if any(
-                token in self.clitranslator_postprocess_command
-                for token in forbidden_templates
-            ):
-                raise ValueError(
-                    "Template variables are not supported in clitranslator_postprocess_command."
-                )
 
 
 ## Please add the translator configuration class above this location.

--- a/pdf2zh_next/translator/translator_impl/cli.py
+++ b/pdf2zh_next/translator/translator_impl/cli.py
@@ -22,14 +22,14 @@ class CLITranslator(BaseTranslator):
 
     Example configurations:
 
-    1. Using plamo-translate:
-       cli_command: "uvx plamo-translate"
+    1. Basic usage:
+       cli_command: "your-translator-command --flag value"
 
     2. Using stdin with custom tool:
-       cli_command: "my-translate --from en --to ja"
+       cli_command: "your-translator-command --from en --to ja"
 
     3. With postprocess command (e.g. jq):
-       cli_command: "translate-api --format json"
+       cli_command: "your-translator-command --format json"
        cli_postprocess_command: "jq -r .result.translation"
 
        Alternative:

--- a/pdf2zh_next/translator/translator_impl/cli.py
+++ b/pdf2zh_next/translator/translator_impl/cli.py
@@ -130,6 +130,8 @@ class CLITranslator(BaseTranslator):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             )
             stdout, stderr = process.communicate(input=text, timeout=self.timeout)
 
@@ -151,13 +153,11 @@ class CLITranslator(BaseTranslator):
 
             return output.strip()
 
-        except subprocess.TimeoutExpired as e:
+        except subprocess.TimeoutExpired:
             if "process" in locals():
                 process.kill()
                 process.communicate()
-            raise ValueError(
-                f"CLI translation timed out after {self.timeout} seconds"
-            ) from e
+            raise
 
     def _run_postprocess(self, output: str) -> str:
         """Run postprocess command on CLI output."""
@@ -171,6 +171,8 @@ class CLITranslator(BaseTranslator):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             )
             stdout, stderr = process.communicate(input=output, timeout=self.timeout)
             if process.returncode != 0:
@@ -186,10 +188,8 @@ class CLITranslator(BaseTranslator):
                     stderr=stderr,
                 )
             return stdout
-        except subprocess.TimeoutExpired as e:
+        except subprocess.TimeoutExpired:
             if "process" in locals():
                 process.kill()
                 process.communicate()
-            raise ValueError(
-                f"CLI postprocess timed out after {self.timeout} seconds"
-            ) from e
+            raise

--- a/pdf2zh_next/translator/translator_impl/cli.py
+++ b/pdf2zh_next/translator/translator_impl/cli.py
@@ -65,6 +65,7 @@ class CLITranslator(BaseTranslator):
         self.postprocess_command_string = cli_settings.cli_postprocess_command
         self.postprocess_command = None
         if self.postprocess_command_string:
+            # Parse once so invalid quoting fails early and the command is cache-keyed.
             try:
                 postprocess_parts = shlex.split(self.postprocess_command_string)
             except ValueError as e:
@@ -80,7 +81,7 @@ class CLITranslator(BaseTranslator):
                 "cli_postprocess_command", self.postprocess_command_string
             )
 
-        # Test if command is available
+        # Best-effort availability check (does not hard-fail if --version is unsupported).
         self._test_command(self.command, label="CLI")
         if self.postprocess_command:
             self._test_command(self.postprocess_command[0], label="Postprocess")
@@ -150,6 +151,7 @@ class CLITranslator(BaseTranslator):
 
             output = stdout
             if self.postprocess_command:
+                # Allow arbitrary stdout transformation (e.g., jq).
                 output = self._run_postprocess(output)
 
             # Parse output based on format

--- a/pdf2zh_next/translator/translator_impl/clitranslator.py
+++ b/pdf2zh_next/translator/translator_impl/clitranslator.py
@@ -34,7 +34,6 @@ class CLITranslatorTranslator(BaseTranslator):
     3. Postprocess command (e.g. jq):
        clitranslator_command: "your-translator-command --format json"
        clitranslator_postprocess_command: "jq -r .result.translation"
-       (or: "jq -r .reqult.translation")
     """
 
     name = "clitranslator"
@@ -156,9 +155,8 @@ class CLITranslatorTranslator(BaseTranslator):
             return output.strip()
 
         except subprocess.TimeoutExpired:
-            if "process" in locals():
-                process.kill()
-                process.communicate()
+            process.kill()
+            process.communicate()
             raise
 
     def _run_postprocess(self, output: str) -> str:
@@ -191,7 +189,6 @@ class CLITranslatorTranslator(BaseTranslator):
                 )
             return stdout
         except subprocess.TimeoutExpired:
-            if "process" in locals():
-                process.kill()
-                process.communicate()
+            process.kill()
+            process.communicate()
             raise

--- a/pdf2zh_next/translator/translator_impl/clitranslator.py
+++ b/pdf2zh_next/translator/translator_impl/clitranslator.py
@@ -88,7 +88,7 @@ class CLITranslatorTranslator(BaseTranslator):
     def _test_command(self, command: str, label: str):
         """Validate that the command is executable or discoverable on PATH."""
         cmd_path = Path(command)
-        if cmd_path.is_absolute() or cmd_path.parent != Path("."):
+        if cmd_path.is_absolute() or cmd_path.parent != Path():
             if not cmd_path.exists():
                 raise ValueError(
                     f"{label} command '{command}' not found. "

--- a/pdf2zh_next/translator/translator_impl/clitranslator.py
+++ b/pdf2zh_next/translator/translator_impl/clitranslator.py
@@ -28,15 +28,13 @@ class CLITranslatorTranslator(BaseTranslator):
     1. Basic usage:
        clitranslator_command: "your-translator-command --flag value"
 
-    2. Using stdin with custom tool:
+    2. Custom flags:
        clitranslator_command: "your-translator-command --from en --to ja"
 
-    3. With postprocess command (e.g. jq):
+    3. Postprocess command (e.g. jq):
        clitranslator_command: "your-translator-command --format json"
        clitranslator_postprocess_command: "jq -r .result.translation"
-
-       Alternative:
-       clitranslator_postprocess_command: "jq -r .reqult.translation"
+       (or: "jq -r .reqult.translation")
     """
 
     name = "clitranslator"

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -235,14 +235,6 @@ class TestCLISettings:
         with pytest.raises(ValueError, match="Template variables are not supported"):
             settings.validate_settings()
 
-    def test_requires_json_path_when_json_output(self):
-        settings = CLISettings(
-            cli_command="uvx plamo-translate",
-            cli_output_format="json",
-        )
-        with pytest.raises(ValueError, match="cli_json_path is required"):
-            settings.validate_settings()
-
     def test_invalid_cli_command(self):
         settings = CLISettings(cli_command="uvx 'unterminated")
         with pytest.raises(ValueError, match="Invalid cli_command"):

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -222,7 +222,7 @@ class TestOpenAISettings:
 
 class TestCLISettings:
     def test_valid_command_with_args_and_stdin_default(self):
-        settings = CLISettings(cli_command="uvx plamo-translate --flag value")
+        settings = CLISettings(cli_command="your-translator-command --flag value")
         settings.validate_settings()
 
     def test_requires_command(self):
@@ -231,25 +231,25 @@ class TestCLISettings:
             settings.validate_settings()
 
     def test_rejects_template_variables(self):
-        settings = CLISettings(cli_command="uvx plamo-translate --input {text}")
+        settings = CLISettings(cli_command="your-translator-command --input {text}")
         with pytest.raises(ValueError, match="Template variables are not supported"):
             settings.validate_settings()
 
     def test_invalid_cli_command(self):
-        settings = CLISettings(cli_command="uvx 'unterminated")
+        settings = CLISettings(cli_command="your-translator-command 'unterminated")
         with pytest.raises(ValueError, match="Invalid cli_command"):
             settings.validate_settings()
 
     def test_valid_postprocess_command(self):
         settings = CLISettings(
-            cli_command="uvx plamo-translate",
+            cli_command="your-translator-command",
             cli_postprocess_command="jq -r .result.translation",
         )
         settings.validate_settings()
 
     def test_rejects_postprocess_templates(self):
         settings = CLISettings(
-            cli_command="uvx plamo-translate",
+            cli_command="your-translator-command",
             cli_postprocess_command="jq -r .result.{text}",
         )
         with pytest.raises(ValueError, match="Template variables are not supported"):
@@ -257,7 +257,7 @@ class TestCLISettings:
 
     def test_invalid_postprocess_command(self):
         settings = CLISettings(
-            cli_command="uvx plamo-translate",
+            cli_command="your-translator-command",
             cli_postprocess_command="jq 'unterminated",
         )
         with pytest.raises(ValueError, match="Invalid cli_postprocess_command"):

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -232,13 +232,6 @@ class TestCLISettings:
         with pytest.raises(ValueError, match="CLI command is required"):
             settings.validate_settings()
 
-    def test_rejects_template_variables(self):
-        settings = CLISettings(
-            clitranslator_command="your-translator-command --input {text}"
-        )
-        with pytest.raises(ValueError, match="Template variables are not supported"):
-            settings.validate_settings()
-
     def test_invalid_cli_command(self):
         settings = CLISettings(
             clitranslator_command="your-translator-command 'unterminated"
@@ -252,14 +245,6 @@ class TestCLISettings:
             clitranslator_postprocess_command="jq -r .result.translation",
         )
         settings.validate_settings()
-
-    def test_rejects_postprocess_templates(self):
-        settings = CLISettings(
-            clitranslator_command="your-translator-command",
-            clitranslator_postprocess_command="jq -r .result.{text}",
-        )
-        with pytest.raises(ValueError, match="Template variables are not supported"):
-            settings.validate_settings()
 
     def test_invalid_postprocess_command(self):
         settings = CLISettings(

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -5,6 +5,7 @@ from pdf2zh_next.config.cli_env_model import CLIEnvSettingsModel
 from pdf2zh_next.config.model import BasicSettings
 from pdf2zh_next.config.model import PDFSettings
 from pdf2zh_next.config.model import TranslationSettings
+from pdf2zh_next.config.translate_engine_model import CLISettings
 from pdf2zh_next.config.translate_engine_model import OpenAISettings
 
 
@@ -217,6 +218,58 @@ class TestOpenAISettings:
         assert settings.openai_model == "gpt-4"
         assert settings.openai_base_url == "http://api.example.com"
         assert settings.openai_api_key == "test-key"
+
+
+class TestCLISettings:
+    def test_valid_command_with_args_and_stdin_default(self):
+        settings = CLISettings(cli_command="uvx plamo-translate --flag value")
+        settings.validate_settings()
+
+    def test_requires_command(self):
+        settings = CLISettings(cli_command="")
+        with pytest.raises(ValueError, match="CLI command is required"):
+            settings.validate_settings()
+
+    def test_rejects_template_variables(self):
+        settings = CLISettings(cli_command="uvx plamo-translate --input {text}")
+        with pytest.raises(ValueError, match="Template variables are not supported"):
+            settings.validate_settings()
+
+    def test_requires_json_path_when_json_output(self):
+        settings = CLISettings(
+            cli_command="uvx plamo-translate",
+            cli_output_format="json",
+        )
+        with pytest.raises(ValueError, match="cli_json_path is required"):
+            settings.validate_settings()
+
+    def test_invalid_cli_command(self):
+        settings = CLISettings(cli_command="uvx 'unterminated")
+        with pytest.raises(ValueError, match="Invalid cli_command"):
+            settings.validate_settings()
+
+    def test_valid_postprocess_command(self):
+        settings = CLISettings(
+            cli_command="uvx plamo-translate",
+            cli_postprocess_command="jq -r .result.translation",
+        )
+        settings.validate_settings()
+
+    def test_rejects_postprocess_templates(self):
+        settings = CLISettings(
+            cli_command="uvx plamo-translate",
+            cli_postprocess_command="jq -r .result.{text}",
+        )
+        with pytest.raises(ValueError, match="Template variables are not supported"):
+            settings.validate_settings()
+
+    def test_invalid_postprocess_command(self):
+        settings = CLISettings(
+            cli_command="uvx plamo-translate",
+            cli_postprocess_command="jq 'unterminated",
+        )
+        with pytest.raises(ValueError, match="Invalid cli_postprocess_command"):
+            settings.validate_settings()
 
     def test_base_url_handling(self):
         """Test base URL handling"""

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -222,45 +222,53 @@ class TestOpenAISettings:
 
 class TestCLISettings:
     def test_valid_command_with_args_and_stdin_default(self):
-        settings = CLISettings(cli_command="your-translator-command --flag value")
+        settings = CLISettings(
+            clitranslator_command="your-translator-command --flag value"
+        )
         settings.validate_settings()
 
     def test_requires_command(self):
-        settings = CLISettings(cli_command="")
+        settings = CLISettings(clitranslator_command="")
         with pytest.raises(ValueError, match="CLI command is required"):
             settings.validate_settings()
 
     def test_rejects_template_variables(self):
-        settings = CLISettings(cli_command="your-translator-command --input {text}")
+        settings = CLISettings(
+            clitranslator_command="your-translator-command --input {text}"
+        )
         with pytest.raises(ValueError, match="Template variables are not supported"):
             settings.validate_settings()
 
     def test_invalid_cli_command(self):
-        settings = CLISettings(cli_command="your-translator-command 'unterminated")
-        with pytest.raises(ValueError, match="Invalid cli_command"):
+        settings = CLISettings(
+            clitranslator_command="your-translator-command 'unterminated"
+        )
+        with pytest.raises(ValueError, match="Invalid clitranslator_command"):
             settings.validate_settings()
 
     def test_valid_postprocess_command(self):
         settings = CLISettings(
-            cli_command="your-translator-command",
-            cli_postprocess_command="jq -r .result.translation",
+            clitranslator_command="your-translator-command",
+            clitranslator_postprocess_command="jq -r .result.translation",
         )
         settings.validate_settings()
 
     def test_rejects_postprocess_templates(self):
         settings = CLISettings(
-            cli_command="your-translator-command",
-            cli_postprocess_command="jq -r .result.{text}",
+            clitranslator_command="your-translator-command",
+            clitranslator_postprocess_command="jq -r .result.{text}",
         )
         with pytest.raises(ValueError, match="Template variables are not supported"):
             settings.validate_settings()
 
     def test_invalid_postprocess_command(self):
         settings = CLISettings(
-            cli_command="your-translator-command",
-            cli_postprocess_command="jq 'unterminated",
+            clitranslator_command="your-translator-command",
+            clitranslator_postprocess_command="jq 'unterminated",
         )
-        with pytest.raises(ValueError, match="Invalid cli_postprocess_command"):
+        with pytest.raises(
+            ValueError, match="Invalid clitranslator_postprocess_command"
+        ):
             settings.validate_settings()
 
     def test_base_url_handling(self):


### PR DESCRIPTION
Hello!

PDFMathTranslate-next is a wonderful project. Thank you for maintaining it — I use it a lot.

This PR adds a simple CLITranslator that enables translation via an external CLI command (stdin-based). It is intentionally minimal: you specify the command via `--cli --cli-command`, and the input text is always passed over stdin. Optionally, you can postprocess the CLI output with `--cli-postprocess-command` (e.g., `jq`) so you can extract text from JSON or any other format.

I personally use [plamo-translate](https://github.com/pfnet/plamo-translate-cli), a CLI-based translation tool, and find it very convenient with `pdf2zh_next`. However, this feature is not limited to plamo-translate — any CLI translation tool should work. For example, if you run `uvx plamo-translate server` in advance, translation is fast on macOS:

```
$ echo 'what is your name?' | time uvx plamo-translate --to Chinese
你的名字是什么？
uvx plamo-translate --to Chinese  0.25s user 0.04s system 59% cpu 0.480 total
```

Then with pdf2zh:

```
pdf2zh input.pdf \
    --cli \
    --cli-command 'uvx plamo-translate --to Chinese'
```

If the CLI returns JSON, postprocess it like this:

```
pdf2zh input.pdf \
    --cli \
    --cli-command 'translate-tool-cli --format json' \
    --cli-postprocess-command 'jq -r .reqult.translation'
```

I know the name `--cli` can feel a bit ambiguous, but I aligned it with the existing `{Class}Translator` flags for consistency.

I’d be happy if you consider merging this!


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stdin-based CLI translator that lets pdf2zh use any external translation command, with optional postprocessing of the output. This enables fast local tools (e.g., plamo-translate) and easy JSON extraction via jq.

- **New Features**
  - Added CLI translator and CLISettings to run an external clitranslator_command via stdin; optional clitranslator_postprocess_command to transform stdout (e.g., jq).
  - Invoke with --translate-engine CLITranslator and --clitranslator-command; optionally --clitranslator-postprocess-command.
  - Includes timeouts, retries, and command availability checks; clear errors with stderr when commands fail.
  - Cache keys include clitranslator_command and clitranslator_postprocess_command to avoid collisions.
  - Tests cover settings validation (required command, quoting errors, postprocess command).

<sup>Written for commit e21df73bde58964abfbc24d47e31ba50fd23acad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



