### PR TITLE
fix: enable auto_enable_ocr_workaround by default for scanned PDF tra…

### DIFF
--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -184,8 +184,8 @@ class PDFSettings(BaseModel):
         description="Force translated text to be black and add white background",
     )
     auto_enable_ocr_workaround: bool = Field(
-        default=False,
-        description="Enable automatic OCR workaround. If a document is detected as heavily scanned, this will attempt to enable OCR processing and skip further scan detection. See documentation for details. (default: False)",
+        default=True,
+        description="Enable automatic OCR workaround. If a document is detected as heavily scanned, this will attempt to enable OCR processing and skip further scan detection. See documentation for details. (default: True)",
     )
     only_include_translated_page: bool = Field(
         default=False,


### PR DESCRIPTION
…nslation

Some scanned PDFs with OCR text layers (using invisible text rendering mode '3 Tr' inside XObject Form streams) were not being properly translated. The translated text was either invisible or covered by the scanned image.

By enabling auto_enable_ocr_workaround by default, the system will:
1. Automatically detect scanned PDFs during translation
2. Enable OCR workaround to make translated text visible (black color)
3. Adjust render order so translated text appears on top of the scanned image
4. Add white background behind translated text for readability

This fixes the issue where some scanned PDFs would produce output identical to the original (untranslated) document.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `auto_enable_ocr_workaround` to true by default to fix translation of scanned PDFs with invisible OCR layers. Translated text now renders in black with a white background above the scanned image, preventing invisible or covered output.

<sup>Written for commit 2d39116c3f0211a5fe12b23ae851c48916429084. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

