### PR TITLE
fix: prevent PowerShell window popups on Windows PyStand build

### DIFF
--- a/pdf2zh_next/high_level.py
+++ b/pdf2zh_next/high_level.py
@@ -115,23 +115,6 @@ def _translate_wrapper(
     pipe_cancel_message_recv: multiprocessing.connection.Connection,
     logger_queue: multiprocessing.Queue,
 ):
-    # Workaround: On Windows, loky (sklearn/joblib dependency) queries
-    # physical CPU cores by spawning powershell.exe without CREATE_NO_WINDOW.
-    # When this subprocess runs under pythonw.exe (PyStand builds), there is
-    # no parent console to inherit, so Windows creates a visible console
-    # window. Multiple ThreadPoolExecutor threads can trigger this simultaneously
-    # due to a cache race condition, producing many popup windows.
-    # Pre-filling loky's cache here prevents the subprocess call entirely.
-    import sys
-    if sys.platform == "win32":
-        try:
-            import joblib.externals.loky.backend.context as _loky_ctx
-            if _loky_ctx.physical_cores_cache is None:
-                import os
-                _loky_ctx.physical_cores_cache = os.cpu_count()
-        except Exception:
-            pass
-
     logger = logging.getLogger(__name__)
     cancel_event = threading.Event()
     try:
@@ -144,6 +127,31 @@ def _translate_wrapper(
 
         queue_handler = QueueHandler(logger_queue)
         logging.basicConfig(level=logging.INFO, handlers=[queue_handler])
+
+        # Workaround for loky spawning powershell.exe on Windows.
+        # loky queries physical CPU cores via powershell.exe without
+        # CREATE_NO_WINDOW. Under pythonw.exe (PyStand), there is no
+        # parent console, so Windows creates visible console windows.
+        # Multiple ThreadPoolExecutor threads hit this simultaneously
+        # (cache race), producing many popups. Pre-filling the cache
+        # prevents the subprocess call entirely.
+        import sys
+        if sys.platform == "win32":
+            try:
+                import joblib.externals.loky.backend.context as _loky_ctx
+                if _loky_ctx.physical_cores_cache is None:
+                    import os
+                    _loky_ctx.physical_cores_cache = os.cpu_count()
+                    logger.info(
+                        "Pre-filled loky physical_cores_cache=%d to prevent "
+                        "PowerShell window popups under pythonw.exe",
+                        os.cpu_count(),
+                    )
+            except Exception:
+                logger.debug(
+                    "Failed to pre-fill loky physical_cores_cache",
+                    exc_info=True,
+                )
 
         config = create_babeldoc_config(settings, file)
 

--- a/pdf2zh_next/high_level.py
+++ b/pdf2zh_next/high_level.py
@@ -115,6 +115,23 @@ def _translate_wrapper(
     pipe_cancel_message_recv: multiprocessing.connection.Connection,
     logger_queue: multiprocessing.Queue,
 ):
+    # Workaround: On Windows, loky (sklearn/joblib dependency) queries
+    # physical CPU cores by spawning powershell.exe without CREATE_NO_WINDOW.
+    # When this subprocess runs under pythonw.exe (PyStand builds), there is
+    # no parent console to inherit, so Windows creates a visible console
+    # window. Multiple ThreadPoolExecutor threads can trigger this simultaneously
+    # due to a cache race condition, producing many popup windows.
+    # Pre-filling loky's cache here prevents the subprocess call entirely.
+    import sys
+    if sys.platform == "win32":
+        try:
+            import joblib.externals.loky.backend.context as _loky_ctx
+            if _loky_ctx.physical_cores_cache is None:
+                import os
+                _loky_ctx.physical_cores_cache = os.cpu_count()
+        except Exception:
+            pass
+
     logger = logging.getLogger(__name__)
     cancel_event = threading.Event()
     try:


### PR DESCRIPTION
### Summary

On the Windows standalone build (PyStand), multiple PowerShell console
windows pop up simultaneously during the "Parse Page Layout" stage of
translation. This PR adds a workaround that pre-fills `loky`'s internal
cache to prevent it from spawning `powershell.exe` at runtime.

### Root cause

`joblib.externals.loky.backend.context._count_physical_cores_win32()`
queries physical CPU cores by spawning `powershell.exe` without the
`CREATE_NO_WINDOW` flag:

```python
# loky/backend/context.py:289
subprocess.run(
    f"powershell.exe -Command (Get-CimInstance -ClassName Win32_Processor).NumberOfCores".split(),
    capture_output=True, text=True,
)
```

This is harmless under `python.exe` (console subsystem) because child
processes silently inherit the parent console. However, the PyStand build
uses `pythonw.exe` (GUI subsystem) for the translation subprocess, which
has **no console**. When `loky` spawns `powershell.exe` from `pythonw.exe`,
Windows must create a new visible console window.

The problem is amplified by a **race condition** in `loky`'s cache: when
`babeldoc`'s `ThreadPoolExecutor(max_workers=os.cpu_count())` creates ~16
threads, they all trigger `loky` initialization simultaneously, each find
the cache empty, and each spawn their own `powershell.exe` — producing ~16
popup windows.

### Fix

Pre-fill `loky`'s `physical_cores_cache` at the start of the translation
subprocess (`_translate_wrapper`), before any `babeldoc` code runs. Once
cached, `loky` skips the PowerShell query entirely.

```python
import sys
if sys.platform == "win32":
    try:
        import joblib.externals.loky.backend.context as _loky_ctx
        if _loky_ctx.physical_cores_cache is None:
            import os
            _loky_ctx.physical_cores_cache = os.cpu_count()
    except Exception:
        pass
```

### Why this location and approach

- **In pdf2zh-next's own code** — does not modify the upstream `babeldoc`
  library, which is not affected by this bug when used with `python.exe`.
- **Inside `_translate_wrapper`** — runs in the `pythonw.exe` subprocess
  where the bug manifests, before any `babeldoc` code executes.
- **`sys.platform == "win32"` guard** — no effect on Linux/macOS.
- **`try/except` wrapped** — gracefully handles future `loky` API changes.

### Why not fix elsewhere

| Location | Issue |
|----------|-------|
| Upstream `loky/joblib` | Proper fix, but requires upstream release cycle. Could be filed separately. |
| Upstream `babeldoc` | Bug is caused by pdf2zh-next's PyStand packaging (pythonw.exe), not babeldoc itself. |
| `_pystand_static.int` | Runs in the main process (pdf2zh.exe, has console), not in the subprocess (pythonw.exe) where the bug occurs. |

### How to reproduce (before fix)

1. Run `pdf2zh.exe` (PyStand standalone build) on Windows.
2. Submit a multi-page PDF translation via the GUI.
3. During "Parse Page Layout", ~16 PowerShell windows flash on screen.

### Test results (after fix)

- [x] Windows 11, PyStand build: **0 popup windows** during full translation
- [x] Translation completes successfully with correct output
- [x] No regression on PyPI distribution (`pdf2zh --gui`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents PowerShell windows from flashing on Windows PyStand builds by pre-filling `loky`’s physical core cache in the translation subprocess. The workaround now runs right after logger init to log its result, still before any `babeldoc` work.

- **Bug Fixes**
  - Pre-fills `joblib.externals.loky` physical core cache in `_translate_wrapper` on `win32` to skip the PowerShell query.
  - Runs early after logger init; logs success/failure; wrapped in try/except; no-op on non-Windows.
  - Eliminates ~16 popup windows; no behavior change on Linux/macOS or CLI builds.

<sup>Written for commit 7e1ce9a92ac9761c210865f26e399d623f18d671. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

