### PR TITLE
Feature/deepseek thinking mode proposal

### DIFF
--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -10,6 +10,7 @@ from typing import TypeAlias
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import PrivateAttr
 from pydantic import create_model
 
 # any field in SENSITIVE_FIELDS will be masked in GUI
@@ -72,6 +73,8 @@ class TranslateEngineSettingError(Exception):
 
 class OpenAISettings(BaseModel):
     """OpenAI API settings"""
+
+    _openai_extra_body: dict[str, typing.Any] | None = PrivateAttr(default=None)
 
     translate_engine_type: Literal["OpenAI"] = Field(default="OpenAI")
     support_llm: Literal["yes", "no"] = Field(
@@ -192,20 +195,36 @@ class DeepSeekSettings(BaseModel):
     deepseek_enable_json_mode: bool | None = Field(
         default=None, description="Enable JSON mode for DeepSeek service"
     )
+    deepseek_thinking_enabled: bool | None = Field(
+        default=False, description="Enable thinking mode for DeepSeek v4 models"
+    )
+    deepseek_reasoning_effort: str | None = Field(
+        default=None, description="Reasoning effort for DeepSeek thinking mode (high/max)"
+    )
 
     def validate_settings(self) -> None:
         if not self.deepseek_api_key:
             raise ValueError("DeepSeek API key is required")
         self.deepseek_api_key = _clean_string(self.deepseek_api_key)
         self.deepseek_model = _clean_string(self.deepseek_model)
+        self.deepseek_reasoning_effort = _clean_string(self.deepseek_reasoning_effort)
+        if self.deepseek_reasoning_effort not in (None, "high", "max"):
+            raise ValueError("DeepSeek reasoning effort must be high or max")
 
     def transform(self) -> OpenAISettings:
-        return OpenAISettings(
+        settings = OpenAISettings(
             openai_model=self.deepseek_model,
             openai_api_key=self.deepseek_api_key,
             openai_base_url="https://api.deepseek.com/v1",
             openai_enable_json_mode=self.deepseek_enable_json_mode,
         )
+        if self.deepseek_model and self.deepseek_model.startswith("deepseek-v4-"):
+            thinking_type = "enabled" if self.deepseek_thinking_enabled else "disabled"
+            settings._openai_extra_body = {"thinking": {"type": thinking_type}}
+            if self.deepseek_thinking_enabled and self.deepseek_reasoning_effort:
+                settings.openai_reasoning_effort = self.deepseek_reasoning_effort
+                settings.openai_send_reasoning_effort = True
+        return settings
 
 
 GUI_PASSWORD_FIELDS.append("deepseek_api_key")

--- a/pdf2zh_next/config/translate_engine_model.py
+++ b/pdf2zh_next/config/translate_engine_model.py
@@ -208,7 +208,10 @@ class DeepSeekSettings(BaseModel):
         self.deepseek_api_key = _clean_string(self.deepseek_api_key)
         self.deepseek_model = _clean_string(self.deepseek_model)
         self.deepseek_reasoning_effort = _clean_string(self.deepseek_reasoning_effort)
-        if self.deepseek_reasoning_effort not in (None, "high", "max"):
+        if self.deepseek_reasoning_effort and self.deepseek_reasoning_effort not in (
+            "high",
+            "max",
+        ):
             raise ValueError("DeepSeek reasoning effort must be high or max")
 
     def transform(self) -> OpenAISettings:

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -1595,7 +1595,7 @@ def on_file_upload(files, state):
     )
 
 
-def on_file_clear(files, state):
+def on_file_clear(_files, state):
     """
     Handle file clear/delete event to clean up state and UI.
     When user clicks the X button on file input, this function removes uploaded files
@@ -2351,10 +2351,16 @@ with gr.Blocks(
 
         translation_engine_arg_inputs = []
         detail_text_inputs = []
+        detail_text_input_field_names = []
         require_llm_translator_inputs = []
         detail_text_input_index_map = {}
         term_detail_text_inputs = []
+        term_detail_text_input_field_names = []
         term_detail_text_input_index_map = {}
+        deepseek_thinking_enabled_input = None
+        deepseek_reasoning_effort_input = None
+        term_deepseek_thinking_enabled_input = None
+        term_deepseek_reasoning_effort_input = None
         LLM_support_index_map.clear()
         with gr.Row(elem_classes=["tab-main-row"], equal_height=True):
             # 左侧侧边栏
@@ -2530,7 +2536,19 @@ with gr.Blocks(
                                     original_type = typing.get_origin(type_hint)
                                     type_args = typing.get_args(type_hint)
                                     value = getattr(detail_settings, field_name)
-                                    if (
+                                    if field_name == "deepseek_reasoning_effort":
+                                        field_input = gr.Dropdown(
+                                            label=field.description,
+                                            choices=["high", "max"],
+                                            value=value or "high",
+                                            interactive=True,
+                                            visible=visible
+                                            and bool(
+                                                detail_settings.deepseek_thinking_enabled
+                                            ),
+                                        )
+                                        deepseek_reasoning_effort_input = field_input
+                                    elif (
                                         type_hint is str
                                         or str in type_args
                                         or type_hint is int
@@ -2558,6 +2576,8 @@ with gr.Blocks(
                                             interactive=True,
                                             visible=visible,
                                         )
+                                        if field_name == "deepseek_thinking_enabled":
+                                            deepseek_thinking_enabled_input = field_input
                                     else:
                                         raise Exception(
                                             f"Unsupported type {type_hint} for field {field_name} in gui translation engine settings"
@@ -2567,6 +2587,7 @@ with gr.Blocks(
                                     ].append(detail_index)
                                     detail_index += 1
                                     detail_text_inputs.append(field_input)
+                                    detail_text_input_field_names.append(field_name)
                                     __gui_service_arg_names.append(field_name)
                                     translation_engine_arg_inputs.append(field_input)
                     with gr.Group() as rate_limit_settings:
@@ -2711,7 +2732,18 @@ with gr.Blocks(
                                         type_args = typing.get_args(type_hint)
                                         value = getattr(term_detail_settings, field_name)
 
-                                        if (
+                                        if field_name == "term_deepseek_reasoning_effort":
+                                            field_input = gr.Dropdown(
+                                                label=field.description,
+                                                choices=["high", "max"],
+                                                value=value or "high",
+                                                interactive=True,
+                                                visible=False,
+                                            )
+                                            term_deepseek_reasoning_effort_input = (
+                                                field_input
+                                            )
+                                        elif (
                                             type_hint is str
                                             or str in type_args
                                             or type_hint is int
@@ -2739,6 +2771,10 @@ with gr.Blocks(
                                                 interactive=True,
                                                 visible=False,
                                             )
+                                            if field_name == "term_deepseek_thinking_enabled":
+                                                term_deepseek_thinking_enabled_input = (
+                                                    field_input
+                                                )
                                         else:
                                             raise Exception(
                                                 f"Unsupported type {type_hint} for field {field_name} in gui term extraction engine settings"
@@ -2749,6 +2785,7 @@ with gr.Blocks(
                                         ].append(term_detail_index)
                                         term_detail_index += 1
                                         term_detail_text_inputs.append(field_input)
+                                        term_detail_text_input_field_names.append(field_name)
                                         __gui_term_service_arg_names.append(field_name)
                                         translation_engine_arg_inputs.append(field_input)
 
@@ -3135,7 +3172,7 @@ with gr.Blocks(
             """Update page input visibility based on selection"""
             return gr.update(visible=choice == "Range")
 
-        def on_select_service(service_name):
+        def on_select_service(service_name, deepseek_thinking_enabled=False):
             """Update service-specific settings visibility"""
             if not detail_text_inputs:
                 return
@@ -3161,11 +3198,38 @@ with gr.Blocks(
                     siliconflow_update
                     + glossary_updates
                     + [
-                        gr.update(visible=(i in detail_group_index))
+                            gr.update(
+                                choices=["high", "max"]
+                                if detail_text_input_field_names[i]
+                                == "deepseek_reasoning_effort"
+                                else None,
+                                value="high"
+                                if detail_text_input_field_names[i]
+                                == "deepseek_reasoning_effort"
+                                else gr.skip(),
+                                visible=(i in detail_group_index)
+                                and (
+                                    detail_text_input_field_names[i]
+                                    != "deepseek_reasoning_effort"
+                                    or bool(deepseek_thinking_enabled)
+                                ),
+                            )
                         for i in range(len(detail_text_inputs))
                     ]
                 )
             return return_list
+
+        def on_deepseek_thinking_enabled_change(enabled, service_name):
+            return gr.update(
+                choices=["high", "max"],
+                value="high", visible=enabled and service_name == "DeepSeek"
+            )
+
+        def on_term_deepseek_thinking_enabled_change(enabled, term_service_name):
+            return gr.update(
+                choices=["high", "max"],
+                value="high", visible=enabled and term_service_name == "DeepSeek"
+            )
 
         def on_enhance_compatibility_change(enhance_value):
             """Update skip_clean and disable_rich_text_translate when enhance_compatibility changes"""
@@ -3237,7 +3301,9 @@ with gr.Blocks(
                 gr.update(visible=custom_visible),
             ]
 
-        def on_term_service_change(term_service_name: str):
+        def on_term_service_change(
+            term_service_name: str, term_deepseek_thinking_enabled=False
+        ):
             """Update term engine-specific settings visibility"""
             if not term_detail_text_inputs:
                 return
@@ -3247,13 +3313,26 @@ with gr.Blocks(
             if len(term_detail_text_inputs) == 1:
                 return [gr.update(visible=(0 in detail_group_index))]
             return [
-                gr.update(visible=(i in detail_group_index))
+                gr.update(
+                    value="high"
+                    if term_detail_text_input_field_names[i]
+                    == "term_deepseek_reasoning_effort"
+                    else gr.skip(),
+                    visible=(i in detail_group_index)
+                    and (
+                        term_detail_text_input_field_names[i]
+                        != "term_deepseek_reasoning_effort"
+                        or bool(term_deepseek_thinking_enabled)
+                    ),
+                )
                 for i in range(len(term_detail_text_inputs))
             ]
 
-        def on_service_change_with_rate_limit(mode, service_name):
+        def on_service_change_with_rate_limit(
+            mode, service_name, deepseek_thinking_enabled=False
+        ):
             """Expand original on_select_service with rate-limit-UI updated"""
-            original_updates = on_select_service(service_name)
+            original_updates = on_select_service(service_name, deepseek_thinking_enabled)
 
             rate_limit_visible = service_name != "SiliconFlowFree"
 
@@ -3355,7 +3434,7 @@ with gr.Blocks(
 
         service.select(
             on_service_change_with_rate_limit,
-            [rate_limit_mode, service],
+            [rate_limit_mode, service, deepseek_thinking_enabled_input],
             outputs=(
                 on_select_service_outputs
                 if len(on_select_service_outputs) > 0
@@ -3423,11 +3502,28 @@ with gr.Blocks(
         # Term service change handler
         term_service.change(
             on_term_service_change,
-            term_service,
+            [term_service, term_deepseek_thinking_enabled_input],
             outputs=(
                 term_detail_text_inputs if len(term_detail_text_inputs) > 0 else None
             ),
         )
+
+        if deepseek_thinking_enabled_input and deepseek_reasoning_effort_input:
+            deepseek_thinking_enabled_input.change(
+                on_deepseek_thinking_enabled_change,
+                [deepseek_thinking_enabled_input, service],
+                deepseek_reasoning_effort_input,
+            )
+
+        if (
+            term_deepseek_thinking_enabled_input
+            and term_deepseek_reasoning_effort_input
+        ):
+            term_deepseek_thinking_enabled_input.change(
+                on_term_deepseek_thinking_enabled_change,
+                [term_deepseek_thinking_enabled_input, term_service],
+                term_deepseek_reasoning_effort_input,
+            )
 
         # UI setting controls list (shared by translate_btn and save_btn)
         ui_setting_controls = [
@@ -3813,6 +3909,11 @@ with gr.Blocks(
                             continue
                         value = getattr(detail_settings, field_name)
                         visible = metadata.translate_engine_type == selected_service
+                        if field_name == "deepseek_reasoning_effort":
+                            visible = visible and bool(
+                                detail_settings.deepseek_thinking_enabled
+                            )
+                            value = value or "high"
                         updates.append(gr.update(value=value, visible=visible))
 
                 # Term extraction engine detail fields (ordered)
@@ -3847,6 +3948,11 @@ with gr.Blocks(
                         visible = (
                             term_metadata.translate_engine_type == selected_term_service
                         )
+                        if field_name == "term_deepseek_reasoning_effort":
+                            visible = visible and bool(
+                                term_detail_settings.term_deepseek_thinking_enabled
+                            )
+                            value = value or "high"
                         updates.append(gr.update(value=value, visible=visible))
 
                 # Extra UI components at the end of ui_setting_controls

--- a/pdf2zh_next/gui_translation.yaml
+++ b/pdf2zh_next/gui_translation.yaml
@@ -27,6 +27,8 @@ de:
   Download Translation (Dual): Übersetzung herunterladen (Dual)
   Download Translation (Mono): Übersetzung herunterladen (Mono)
   Download automatically extracted glossary: Automatisch extrahiertes Glossar herunterladen
+  Enable thinking mode for DeepSeek v4 models: Denkmodus für DeepSeek-v4-Modelle aktivieren
+  Reasoning effort for DeepSeek thinking mode (high/max): Reasoning-Aufwand für DeepSeek-Denkmodus (high/max)
   Effective only when a page range is specified.: Nur wirksam, wenn ein Seitenbereich angegeben ist.
   Enable auto term extraction: Automatische Begriffsermittlung aktivieren
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Kompatibilität verbessern (aktiviert automatisch skip_clean und disable_rich_text)
@@ -127,6 +129,8 @@ en:
   Download Translation (Dual): Download Translation (Dual)
   Download Translation (Mono): Download Translation (Mono)
   Download automatically extracted glossary: Download automatically extracted glossary
+  Enable thinking mode for DeepSeek v4 models: Enable thinking mode for DeepSeek v4 models
+  Reasoning effort for DeepSeek thinking mode (high/max): Reasoning effort for DeepSeek thinking mode (high/max)
   Effective only when a page range is specified.: Effective only when a page range is specified.
   Enable auto term extraction: Enable auto term extraction
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Enhance compatibility (auto-enables skip_clean and disable_rich_text)
@@ -227,6 +231,8 @@ es:
   Download Translation (Dual): Descargar Traducción (Dual)
   Download Translation (Mono): Descargar traducción (Mono)
   Download automatically extracted glossary: Descargar glosario extraído automáticamente
+  Enable thinking mode for DeepSeek v4 models: Activar modo de pensamiento para modelos DeepSeek v4
+  Reasoning effort for DeepSeek thinking mode (high/max): Esfuerzo de razonamiento para modo de pensamiento DeepSeek (high/max)
   Effective only when a page range is specified.: Solo tiene efecto cuando se especifica un rango de páginas.
   Enable auto term extraction: Habilitar extracción automática de términos
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Mejorar compatibilidad (activa automáticamente skip_clean y disable_rich_text)
@@ -327,6 +333,8 @@ fr:
   Download Translation (Dual): Télécharger la traduction (Bilingue)
   Download Translation (Mono): Télécharger la traduction (Mono)
   Download automatically extracted glossary: Télécharger le glossaire extrait automatiquement
+  Enable thinking mode for DeepSeek v4 models: Activer le mode réflexion pour les modèles DeepSeek v4
+  Reasoning effort for DeepSeek thinking mode (high/max): Effort de raisonnement pour le mode réflexion DeepSeek (high/max)
   Effective only when a page range is specified.: Efficace uniquement lorsqu'une plage de pages est spécifiée.
   Enable auto term extraction: Activer l'extraction automatique de termes
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Améliorer la compatibilité (active automatiquement skip_clean et disable_rich_text)
@@ -427,6 +435,8 @@ it:
   Download Translation (Dual): Scarica traduzione (Doppia)
   Download Translation (Mono): Scarica Traduzione (Mono)
   Download automatically extracted glossary: Scarica il glossario estratto automaticamente
+  Enable thinking mode for DeepSeek v4 models: Abilita modalità pensiero per i modelli DeepSeek v4
+  Reasoning effort for DeepSeek thinking mode (high/max): Sforzo di ragionamento per modalità pensiero DeepSeek (high/max)
   Effective only when a page range is specified.: Effettivo solo se è specificato un intervallo di pagine.
   Enable auto term extraction: Abilita estrazione automatica dei termini
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Migliora compatibilità (abilita automaticamente skip_clean e disable_rich_text)
@@ -532,6 +542,8 @@ ja:
   Download Translation (Dual): 翻訳をダウンロード（双方向）
   Download Translation (Mono): 翻訳のダウンロード (モノ)
   Download automatically extracted glossary: 自動抽出された用語集をダウンロード
+  Enable thinking mode for DeepSeek v4 models: DeepSeek v4 モデルの思考モードを有効にする
+  Reasoning effort for DeepSeek thinking mode (high/max): DeepSeek 思考モードの reasoning effort (high/max)
   Effective only when a page range is specified.: ページ範囲が指定されている場合にのみ有効
   Enable auto term extraction: 自動用語抽出を有効にする
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): 互換性を向上（skip_clean と disable_rich_text を自動で有効化）
@@ -632,6 +644,8 @@ ko:
   Download Translation (Dual): 번역본 다운로드 (이중)
   Download Translation (Mono): 번역본 다운로드 (모노)
   Download automatically extracted glossary: 자동으로 추출된 용어집 다운로드
+  Enable thinking mode for DeepSeek v4 models: DeepSeek v4 모델의 사고 모드 활성화
+  Reasoning effort for DeepSeek thinking mode (high/max): DeepSeek 사고 모드의 reasoning effort (high/max)
   Effective only when a page range is specified.: 페이지 범위를 지정한 경우에만 유효합니다.
   Enable auto term extraction: 자동 용어 추출 활성화
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): 호환성 향상 (skip_clean 및 disable_rich_text 자동 활성화)
@@ -732,6 +746,8 @@ pt:
   Download Translation (Dual): Baixar Tradução (Dual)
   Download Translation (Mono): Baixar Tradução (Mono)
   Download automatically extracted glossary: Baixar glossário extraído automaticamente
+  Enable thinking mode for DeepSeek v4 models: Ativar modo de pensamento para modelos DeepSeek v4
+  Reasoning effort for DeepSeek thinking mode (high/max): Esforço de raciocínio para modo de pensamento DeepSeek (high/max)
   Effective only when a page range is specified.: Efetivo apenas quando um intervalo de páginas é especificado.
   Enable auto term extraction: Ativar extração automática de termos
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Melhorar compatibilidade (ativa automaticamente skip_clean e disable_rich_text)
@@ -832,6 +848,8 @@ ru:
   Download Translation (Dual): Скачать перевод (Двойной)
   Download Translation (Mono): Скачать перевод (Моно)
   Download automatically extracted glossary: Скачать автоматически извлеченный глоссарий
+  Enable thinking mode for DeepSeek v4 models: Включить режим размышления для моделей DeepSeek v4
+  Reasoning effort for DeepSeek thinking mode (high/max): Усилие рассуждения для режима размышления DeepSeek (high/max)
   Effective only when a page range is specified.: Действительно только при указании диапазона страниц.
   Enable auto term extraction: Включить автоматическое извлечение терминов
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): Улучшить совместимость (автоматически включает skip_clean и disable_rich_text)
@@ -932,6 +950,8 @@ zh:
   Download Translation (Dual): 下载翻译（双语）
   Download Translation (Mono): 下载翻译（单语版）
   Download automatically extracted glossary: 下载自动提取的词汇表
+  Enable thinking mode for DeepSeek v4 models: 启用 DeepSeek v4 模型思考模式
+  Reasoning effort for DeepSeek thinking mode (high/max): DeepSeek 思考模式推理强度（high/max）
   Effective only when a page range is specified.: 仅在指定页面范围时有效。
   Enable auto term extraction: 启用自动术语提取
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): 增强兼容性（自动启用 skip_clean 和 disable_rich_text）
@@ -1032,6 +1052,8 @@ zh-TW:
   Download Translation (Dual): 下載翻譯（雙語）
   Download Translation (Mono): 下載翻譯 (單聲道)
   Download automatically extracted glossary: 下載自動擷取的詞彙表
+  Enable thinking mode for DeepSeek v4 models: 啟用 DeepSeek v4 模型思考模式
+  Reasoning effort for DeepSeek thinking mode (high/max): DeepSeek 思考模式推理強度（high/max）
   Effective only when a page range is specified.: 僅在指定頁面範圍時有效。
   Enable auto term extraction: 啟用自動術語擷取
   Enhance compatibility (auto-enables skip_clean and disable_rich_text): 增強相容性（自動啟用 skip_clean 和 disable_rich_text）

--- a/pdf2zh_next/translator/translator_impl/openai.py
+++ b/pdf2zh_next/translator/translator_impl/openai.py
@@ -54,6 +54,10 @@ class OpenAITranslator(BaseTranslator):
         if self.send_reasoning_effort and self.reasoning_effort:
             self.add_cache_impact_parameters("reasoning_effort", self.reasoning_effort)
             self.options["reasoning_effort"] = self.reasoning_effort
+        self.extra_body = getattr(settings.translate_engine_settings, "_openai_extra_body", None)
+        if self.extra_body:
+            self.add_cache_impact_parameters("extra_body", self.extra_body)
+            self.options["extra_body"] = self.extra_body
 
         self.model = settings.translate_engine_settings.openai_model
         self.add_cache_impact_parameters("model", self.model)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds DeepSeek v4 “thinking mode” with a toggle and reasoning effort (high/max) for translation and term extraction, wired through the OpenAI-compatible client. Updates the GUI and i18n so users can enable thinking and pick effort where supported.

- **New Features**
  - DeepSeek settings: `deepseek_thinking_enabled` and `deepseek_reasoning_effort` with validation (only high/max).
  - When using deepseek-v4-* models, sends extra body `{thinking: {type: enabled/disabled}}`; sets reasoning effort only when thinking is enabled.
  - GUI: new toggle and dropdown for both translator and term extractor; auto-shows effort only when thinking is on and service is DeepSeek; persists and loads correctly.
  - I18n strings added for all supported locales.

- **Bug Fixes**
  - Ensure DeepSeek reasoning effort dropdown appears only when thinking is enabled and defaults to “high”.
  - Minor UI cleanup: ignore unused file param on clear event.

<sup>Written for commit c14187de60c5f8dfa848a19046270f4eee2c6ca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

