### PR TITLE
fix(gui): preserve UI language on save

### DIFF
--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -586,7 +586,7 @@ def _build_translate_settings(
     translate_settings = base_settings.clone()
     original_output = translate_settings.translation.output
     original_pages = translate_settings.pdf.pages
-    original_gui_settings = config_manager.config_cli_settings.gui_settings
+    original_gui_settings = translate_settings.gui_settings.model_copy(deep=True)
 
     # Extract UI values
     service = ui_inputs.get("service")

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -108,6 +108,24 @@ def _gui_field_update(field, visible: bool, current_value=None):
     return gr.update(**update_kwargs)
 
 
+def _persisted_gui_settings_with_ui_lang(ui_lang: str):
+    config_cli_settings = getattr(config_manager, "config_cli_settings", None)
+    if config_cli_settings is not None:
+        gui_settings = config_cli_settings.gui_settings.model_copy(deep=True)
+    else:
+        gui_settings = CLIEnvSettingsModel().gui_settings.model_copy(deep=True)
+    gui_settings.ui_lang = ui_lang
+    return gui_settings
+
+
+def _save_gui_language_settings(lang: str) -> None:
+    settings.gui_settings.ui_lang = lang
+    update_current_languages(lang)
+    config_save_settings = settings.clone()
+    config_save_settings.gui_settings = _persisted_gui_settings_with_ui_lang(lang)
+    config_manager.write_user_default_config_file(settings=config_save_settings)
+
+
 # The following variables associate strings with specific languages
 lang_map = {
     "English": "en",
@@ -908,7 +926,11 @@ def _build_translate_settings(
         # SaveMode.never: should_save remains False
 
         if should_save:
-            config_manager.write_user_default_config_file(settings=translate_settings)
+            config_save_settings = translate_settings.clone()
+            config_save_settings.gui_settings = _persisted_gui_settings_with_ui_lang(
+                translate_settings.gui_settings.ui_lang
+            )
+            config_manager.write_user_default_config_file(settings=config_save_settings)
             global settings
             settings = translate_settings
         temp_settings.validate_settings()
@@ -3467,10 +3489,7 @@ with gr.Blocks(
             return original_updates + rate_limit_updates + detailed_visible
 
         def on_lang_selector_change(lang):
-            settings.gui_settings.ui_lang = lang
-            update_current_languages(lang)
-            config_manager.write_user_default_config_file(settings=settings.clone())
-            return
+            _save_gui_language_settings(lang)
 
         # UI language change handler
 

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -108,6 +108,58 @@ def _gui_field_update(field, visible: bool, current_value=None):
     return gr.update(**update_kwargs)
 
 
+def _enhance_compatibility_option_updates(enhance_value: bool):
+    if enhance_value:
+        return (
+            gr.update(**_enhance_compatibility_control_policy(True, False)),
+            gr.update(**_enhance_compatibility_control_policy(True, False)),
+            gr.update(**_enhance_compatibility_control_policy(True, False)),
+        )
+    return (
+        gr.update(interactive=True),
+        gr.update(interactive=True),
+        gr.update(interactive=True),
+    )
+
+
+def _enhance_compatibility_control_policy(
+    enhance_value: bool,
+    configured_value: bool,
+) -> dict[str, bool]:
+    return {
+        "value": True if enhance_value else configured_value,
+        "interactive": not enhance_value,
+    }
+
+
+def _enhance_compatibility_config_updates(
+    enhance_value: bool,
+    skip_clean_value: bool,
+    disable_rich_text_translate_value: bool,
+    dual_translate_first_value: bool,
+):
+    return (
+        gr.update(
+            **_enhance_compatibility_control_policy(
+                enhance_value,
+                skip_clean_value,
+            )
+        ),
+        gr.update(
+            **_enhance_compatibility_control_policy(
+                enhance_value,
+                disable_rich_text_translate_value,
+            )
+        ),
+        gr.update(
+            **_enhance_compatibility_control_policy(
+                enhance_value,
+                dual_translate_first_value,
+            )
+        ),
+    )
+
+
 def _persisted_gui_settings_with_ui_lang(ui_lang: str):
     config_cli_settings = getattr(config_manager, "config_cli_settings", None)
     if config_cli_settings is not None:
@@ -3001,6 +3053,24 @@ with gr.Blocks(
 
                     # PDF Output Options
                     gr.Markdown(_("## PDF Output Options"))
+                    compatibility_dual_translate_first_policy = (
+                        _enhance_compatibility_control_policy(
+                            settings.pdf.enhance_compatibility,
+                            settings.pdf.dual_translate_first,
+                        )
+                    )
+                    compatibility_skip_clean_policy = (
+                        _enhance_compatibility_control_policy(
+                            settings.pdf.enhance_compatibility,
+                            settings.pdf.skip_clean,
+                        )
+                    )
+                    compatibility_disable_rich_text_translate_policy = (
+                        _enhance_compatibility_control_policy(
+                            settings.pdf.enhance_compatibility,
+                            settings.pdf.disable_rich_text_translate,
+                        )
+                    )
                     with gr.Row():
                         no_mono = gr.Checkbox(
                             label=_("Disable monolingual output"),
@@ -3016,8 +3086,10 @@ with gr.Blocks(
                     with gr.Row():
                         dual_translate_first = gr.Checkbox(
                             label=_("Put translated pages first in dual mode"),
-                            value=settings.pdf.dual_translate_first,
-                            interactive=True,
+                            value=compatibility_dual_translate_first_policy["value"],
+                            interactive=compatibility_dual_translate_first_policy[
+                                "interactive"
+                            ],
                         )
                         use_alternating_pages_dual = gr.Checkbox(
                             label=_("Use alternating pages for dual PDF"),
@@ -3110,16 +3182,20 @@ with gr.Blocks(
 
                         skip_clean = gr.Checkbox(
                             label=_("Skip clean (maybe improve compatibility)"),
-                            value=settings.pdf.skip_clean,
-                            interactive=True,
+                            value=compatibility_skip_clean_policy["value"],
+                            interactive=compatibility_skip_clean_policy["interactive"],
                         )
 
                         disable_rich_text_translate = gr.Checkbox(
                             label=_(
                                 "Disable rich text translation (maybe improve compatibility)"
                             ),
-                            value=settings.pdf.disable_rich_text_translate,
-                            interactive=True,
+                            value=compatibility_disable_rich_text_translate_policy[
+                                "value"
+                            ],
+                            interactive=compatibility_disable_rich_text_translate_policy[
+                                "interactive"
+                            ],
                         )
 
                         enhance_compatibility = gr.Checkbox(
@@ -3369,19 +3445,8 @@ with gr.Blocks(
             return on_dependency_change
 
         def on_enhance_compatibility_change(enhance_value):
-            """Update skip_clean and disable_rich_text_translate when enhance_compatibility changes"""
-            if enhance_value:
-                # When enhanced compatibility is enabled, both options are auto-enabled and disabled for user modification
-                return (
-                    gr.update(value=True, interactive=False),
-                    gr.update(value=True, interactive=False),
-                )
-            else:
-                # When disabled, allow user to modify these settings
-                return (
-                    gr.update(interactive=True),
-                    gr.update(interactive=True),
-                )
+            """Update compatibility options when enhance_compatibility changes."""
+            return _enhance_compatibility_option_updates(enhance_value)
 
         def on_split_short_lines_change(split_value):
             """Update short_line_split_factor visibility based on split_short_lines value"""
@@ -3607,7 +3672,7 @@ with gr.Blocks(
         enhance_compatibility.change(
             on_enhance_compatibility_change,
             enhance_compatibility,
-            [skip_clean, disable_rich_text_translate],
+            [skip_clean, disable_rich_text_translate, dual_translate_first],
         )
 
         # Add event handler for split_short_lines
@@ -3885,9 +3950,19 @@ with gr.Blocks(
                     updates.append(gr.update(value="Range"))
                     updates.append(gr.update(value=str(pages_setting), visible=True))
                 # PDF Output Options
+                (
+                    skip_clean_update,
+                    disable_rich_text_translate_update,
+                    dual_translate_first_update,
+                ) = _enhance_compatibility_config_updates(
+                    fresh_settings.pdf.enhance_compatibility,
+                    fresh_settings.pdf.skip_clean,
+                    fresh_settings.pdf.disable_rich_text_translate,
+                    fresh_settings.pdf.dual_translate_first,
+                )
                 updates.append(gr.update(value=fresh_settings.pdf.no_mono))
                 updates.append(gr.update(value=fresh_settings.pdf.no_dual))
-                updates.append(gr.update(value=fresh_settings.pdf.dual_translate_first))
+                updates.append(dual_translate_first_update)
                 updates.append(
                     gr.update(value=fresh_settings.pdf.use_alternating_pages_dual)
                 )
@@ -3947,10 +4022,8 @@ with gr.Blocks(
                     else fresh_settings.translation.primary_font_family
                 )
                 updates.append(gr.update(value=primary_font_display))
-                updates.append(gr.update(value=fresh_settings.pdf.skip_clean))
-                updates.append(
-                    gr.update(value=fresh_settings.pdf.disable_rich_text_translate)
-                )
+                updates.append(skip_clean_update)
+                updates.append(disable_rich_text_translate_update)
                 updates.append(
                     gr.update(value=fresh_settings.pdf.enhance_compatibility)
                 )

--- a/tests/test_gui_release_blockers.py
+++ b/tests/test_gui_release_blockers.py
@@ -2,6 +2,9 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+from pdf2zh_next.config.cli_env_model import CLIEnvSettingsModel
+
 
 def _gui(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["pytest"])
@@ -19,6 +22,58 @@ def _empty_state():
         "display_map": {},
         "parent_map": {},
         "uploaded_files": [],
+    }
+
+
+def _base_gui_inputs():
+    return {
+        "service": "SiliconFlowFree",
+        "lang_from": "English",
+        "lang_to": "Simplified Chinese",
+        "page_range": "All",
+        "page_input": "",
+        "prompt": "",
+        "ignore_cache": False,
+        "no_mono": False,
+        "no_dual": False,
+        "dual_translate_first": False,
+        "use_alternating_pages_dual": False,
+        "watermark_output_mode": "No Watermark",
+        "rate_limit_mode": "Custom",
+        "custom_qps": 4,
+        "custom_pool_workers": None,
+        "min_text_length": 5,
+        "rpc_doclayout": "",
+        "enable_auto_term_extraction": False,
+        "primary_font_family": "Auto",
+        "skip_clean": False,
+        "disable_rich_text_translate": False,
+        "enhance_compatibility": False,
+        "split_short_lines": False,
+        "short_line_split_factor": 0.8,
+        "translate_table_text": False,
+        "skip_scanned_detection": False,
+        "ocr_workaround": False,
+        "max_pages_per_part": 0,
+        "formular_font_pattern": "",
+        "formular_char_pattern": "",
+        "auto_enable_ocr_workaround": False,
+        "only_include_translated_page": False,
+        "merge_alternating_line_numbers": True,
+        "remove_non_formula_lines": True,
+        "non_formula_line_iou_threshold": 0.5,
+        "figure_table_protection_threshold": 0.5,
+        "skip_formula_offset_calculation": False,
+        "term_service": "Follow main translation engine",
+        "term_rate_limit_mode": "Custom",
+        "term_rpm_input": 240,
+        "term_concurrent_threads": 20,
+        "term_custom_qps": 4,
+        "term_custom_pool_workers": None,
+        "custom_system_prompt_input": "",
+        "glossaries": None,
+        "save_auto_extracted_glossary": False,
+        "siliconflow_free_enable_json_mode": False,
     }
 
 
@@ -74,3 +129,45 @@ def test_on_file_upload_none_returns_all_declared_outputs(monkeypatch):
     assert result[1] is state
     assert result[2]["value"] == ""
     assert result[2]["visible"] is False
+
+
+@pytest.mark.parametrize("save_mode_name", ["always", "follow_settings"])
+def test_build_translate_settings_preserves_current_gui_language_on_save(
+    tmp_path, monkeypatch, save_mode_name
+):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+    startup_settings = gui.config_manager.config_cli_settings.clone()
+    startup_settings.gui_settings.ui_lang = "en"
+    monkeypatch.setattr(gui.config_manager, "config_cli_settings", startup_settings)
+
+    current_settings = CLIEnvSettingsModel()
+    current_settings.gui_settings.ui_lang = "zh"
+    current_settings.gui_settings.disable_config_auto_save = False
+    monkeypatch.setattr(gui, "settings", current_settings.clone())
+
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    gui._build_translate_settings(
+        current_settings,
+        input_pdf,
+        output_dir,
+        getattr(gui.SaveMode, save_mode_name),
+        _base_gui_inputs(),
+    )
+
+    assert len(captured_settings) == 1
+    assert captured_settings[0].gui_settings.ui_lang == "zh"
+    assert gui.settings.gui_settings.ui_lang == "zh"

--- a/tests/test_gui_release_blockers.py
+++ b/tests/test_gui_release_blockers.py
@@ -131,6 +131,116 @@ def test_on_file_upload_none_returns_all_declared_outputs(monkeypatch):
     assert result[2]["visible"] is False
 
 
+def test_enhance_compatibility_update_forces_all_babeldoc_compatibility_flags(
+    monkeypatch,
+):
+    gui = _gui(monkeypatch)
+
+    result = gui._enhance_compatibility_option_updates(True)
+
+    assert result == (
+        {"value": True, "interactive": False, "__type__": "update"},
+        {"value": True, "interactive": False, "__type__": "update"},
+        {"value": True, "interactive": False, "__type__": "update"},
+    )
+
+
+def test_enhance_compatibility_update_restores_all_compatibility_controls(
+    monkeypatch,
+):
+    gui = _gui(monkeypatch)
+
+    result = gui._enhance_compatibility_option_updates(False)
+
+    assert result == (
+        {"interactive": True, "__type__": "update"},
+        {"interactive": True, "__type__": "update"},
+        {"interactive": True, "__type__": "update"},
+    )
+
+
+def test_enhance_compatibility_initial_policy_forces_configured_false_controls(
+    monkeypatch,
+):
+    gui = _gui(monkeypatch)
+
+    result = gui._enhance_compatibility_control_policy(
+        enhance_value=True,
+        configured_value=False,
+    )
+
+    assert result == {"value": True, "interactive": False}
+
+
+def test_enhance_compatibility_reload_updates_restore_configured_false_values(
+    monkeypatch,
+):
+    gui = _gui(monkeypatch)
+
+    result = gui._enhance_compatibility_config_updates(
+        enhance_value=False,
+        skip_clean_value=False,
+        disable_rich_text_translate_value=False,
+        dual_translate_first_value=False,
+    )
+
+    assert result == (
+        {"value": False, "interactive": True, "__type__": "update"},
+        {"value": False, "interactive": True, "__type__": "update"},
+        {"value": False, "interactive": True, "__type__": "update"},
+    )
+
+
+def test_enhance_compatibility_reload_updates_force_configured_false_values(
+    monkeypatch,
+):
+    gui = _gui(monkeypatch)
+
+    result = gui._enhance_compatibility_config_updates(
+        enhance_value=True,
+        skip_clean_value=False,
+        disable_rich_text_translate_value=False,
+        dual_translate_first_value=False,
+    )
+
+    assert result == (
+        {"value": True, "interactive": False, "__type__": "update"},
+        {"value": True, "interactive": False, "__type__": "update"},
+        {"value": True, "interactive": False, "__type__": "update"},
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"skip_clean": True},
+        {"disable_rich_text_translate": True},
+        {"skip_clean": True, "disable_rich_text_translate": True},
+    ],
+)
+def test_standalone_compatibility_options_do_not_force_dual_translate_first(
+    tmp_path, monkeypatch, overrides
+):
+    gui = _gui(monkeypatch)
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    gui_inputs = _base_gui_inputs() | overrides
+    gui_inputs["dual_translate_first"] = False
+    gui_inputs["enhance_compatibility"] = False
+
+    translate_settings = gui._build_translate_settings(
+        CLIEnvSettingsModel(),
+        input_pdf,
+        output_dir,
+        gui.SaveMode.never,
+        gui_inputs,
+    )
+
+    assert translate_settings.pdf.dual_translate_first is False
+
+
 @pytest.mark.parametrize("save_mode_name", ["always", "follow_settings"])
 def test_build_translate_settings_preserves_current_gui_language_on_save(
     tmp_path, monkeypatch, save_mode_name

--- a/tests/test_gui_release_blockers.py
+++ b/tests/test_gui_release_blockers.py
@@ -148,10 +148,21 @@ def test_build_translate_settings_preserves_current_gui_language_on_save(
     )
     startup_settings = gui.config_manager.config_cli_settings.clone()
     startup_settings.gui_settings.ui_lang = "en"
+    startup_settings.gui_settings.server_port = 7860
+    startup_settings.gui_settings.share = False
+    startup_settings.gui_settings.auth_file = None
+    startup_settings.gui_settings.welcome_page = "snapshot-welcome.md"
+    startup_settings.gui_settings.disable_gui_sensitive_input = True
+    startup_settings.gui_settings.disable_config_auto_save = True
     monkeypatch.setattr(gui.config_manager, "config_cli_settings", startup_settings)
 
     current_settings = CLIEnvSettingsModel()
     current_settings.gui_settings.ui_lang = "zh"
+    current_settings.gui_settings.server_port = 9999
+    current_settings.gui_settings.share = True
+    current_settings.gui_settings.auth_file = str(tmp_path / "runtime-auth.csv")
+    current_settings.gui_settings.welcome_page = "runtime-welcome.md"
+    current_settings.gui_settings.disable_gui_sensitive_input = False
     current_settings.gui_settings.disable_config_auto_save = False
     monkeypatch.setattr(gui, "settings", current_settings.clone())
 
@@ -170,4 +181,273 @@ def test_build_translate_settings_preserves_current_gui_language_on_save(
 
     assert len(captured_settings) == 1
     assert captured_settings[0].gui_settings.ui_lang == "zh"
+    assert captured_settings[0].gui_settings.server_port == 7860
+    assert captured_settings[0].gui_settings.share is False
+    assert captured_settings[0].gui_settings.auth_file is None
+    assert captured_settings[0].gui_settings.welcome_page == "snapshot-welcome.md"
+    assert captured_settings[0].gui_settings.disable_gui_sensitive_input is True
+    assert captured_settings[0].gui_settings.disable_config_auto_save is True
     assert gui.settings.gui_settings.ui_lang == "zh"
+    assert gui.settings.gui_settings.server_port == 9999
+    assert gui.settings.gui_settings.share is True
+    assert gui.settings.gui_settings.auth_file == str(tmp_path / "runtime-auth.csv")
+    assert gui.settings.gui_settings.welcome_page == "runtime-welcome.md"
+    assert gui.settings.gui_settings.disable_gui_sensitive_input is False
+    assert gui.settings.gui_settings.disable_config_auto_save is False
+
+
+def test_build_translate_settings_follow_settings_respects_auto_save_disabled(
+    tmp_path, monkeypatch
+):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+
+    current_settings = CLIEnvSettingsModel()
+    current_settings.gui_settings.disable_config_auto_save = True
+
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    gui._build_translate_settings(
+        current_settings,
+        input_pdf,
+        output_dir,
+        gui.SaveMode.follow_settings,
+        _base_gui_inputs(),
+    )
+
+    assert captured_settings == []
+
+
+def test_build_translate_settings_never_save_mode_skips_config_write(
+    tmp_path, monkeypatch
+):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+
+    current_settings = CLIEnvSettingsModel()
+
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    gui._build_translate_settings(
+        current_settings,
+        input_pdf,
+        output_dir,
+        gui.SaveMode.never,
+        _base_gui_inputs(),
+    )
+
+    assert captured_settings == []
+
+
+@pytest.mark.parametrize("save_mode_name", ["never", "follow_settings"])
+def test_build_translate_settings_no_config_snapshot_skips_no_save_without_crash(
+    tmp_path, monkeypatch, save_mode_name
+):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+    monkeypatch.setattr(gui.config_manager, "config_cli_settings", None)
+
+    current_settings = CLIEnvSettingsModel()
+    current_settings.gui_settings.disable_config_auto_save = True
+
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    gui._build_translate_settings(
+        current_settings,
+        input_pdf,
+        output_dir,
+        getattr(gui.SaveMode, save_mode_name),
+        _base_gui_inputs(),
+    )
+
+    assert captured_settings == []
+
+
+@pytest.mark.parametrize("save_mode_name", ["always", "follow_settings"])
+def test_build_translate_settings_no_config_snapshot_saves_safe_gui_defaults(
+    tmp_path, monkeypatch, save_mode_name
+):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+    monkeypatch.setattr(gui.config_manager, "config_cli_settings", None)
+
+    current_settings = CLIEnvSettingsModel()
+    current_settings.gui_settings.ui_lang = "zh"
+    current_settings.gui_settings.server_port = 9999
+    current_settings.gui_settings.share = True
+    current_settings.gui_settings.auth_file = str(tmp_path / "runtime-auth.csv")
+    current_settings.gui_settings.welcome_page = "runtime-welcome.md"
+    current_settings.gui_settings.disable_gui_sensitive_input = True
+    current_settings.gui_settings.disable_config_auto_save = False
+    monkeypatch.setattr(gui, "settings", current_settings.clone())
+
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    gui._build_translate_settings(
+        current_settings,
+        input_pdf,
+        output_dir,
+        getattr(gui.SaveMode, save_mode_name),
+        _base_gui_inputs(),
+    )
+
+    default_gui_settings = CLIEnvSettingsModel().gui_settings
+    assert len(captured_settings) == 1
+    assert captured_settings[0].gui_settings.ui_lang == "zh"
+    assert captured_settings[0].gui_settings.server_port == default_gui_settings.server_port
+    assert captured_settings[0].gui_settings.share == default_gui_settings.share
+    assert captured_settings[0].gui_settings.auth_file == default_gui_settings.auth_file
+    assert captured_settings[0].gui_settings.welcome_page == default_gui_settings.welcome_page
+    assert (
+        captured_settings[0].gui_settings.disable_gui_sensitive_input
+        == default_gui_settings.disable_gui_sensitive_input
+    )
+    assert (
+        captured_settings[0].gui_settings.disable_config_auto_save
+        == default_gui_settings.disable_config_auto_save
+    )
+    assert gui.settings.gui_settings.ui_lang == "zh"
+    assert gui.settings.gui_settings.server_port == 9999
+    assert gui.settings.gui_settings.share is True
+    assert gui.settings.gui_settings.auth_file == str(tmp_path / "runtime-auth.csv")
+    assert gui.settings.gui_settings.welcome_page == "runtime-welcome.md"
+    assert gui.settings.gui_settings.disable_gui_sensitive_input is True
+    assert gui.settings.gui_settings.disable_config_auto_save is False
+
+
+def test_gui_language_save_preserves_snapshot_gui_security_fields(monkeypatch, tmp_path):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+    def ignore_language_update(_lang):
+        return None
+
+    monkeypatch.setattr(gui, "update_current_languages", ignore_language_update)
+
+    startup_settings = gui.config_manager.config_cli_settings.clone()
+    startup_settings.gui_settings.ui_lang = "en"
+    startup_settings.gui_settings.server_port = 7860
+    startup_settings.gui_settings.share = False
+    startup_settings.gui_settings.auth_file = None
+    startup_settings.gui_settings.welcome_page = "snapshot-welcome.md"
+    startup_settings.gui_settings.disable_gui_sensitive_input = True
+    startup_settings.gui_settings.disable_config_auto_save = True
+    monkeypatch.setattr(gui.config_manager, "config_cli_settings", startup_settings)
+
+    current_settings = CLIEnvSettingsModel()
+    current_settings.gui_settings.ui_lang = "en"
+    current_settings.gui_settings.server_port = 9999
+    current_settings.gui_settings.share = True
+    current_settings.gui_settings.auth_file = str(tmp_path / "runtime-auth.csv")
+    current_settings.gui_settings.welcome_page = "runtime-welcome.md"
+    current_settings.gui_settings.disable_gui_sensitive_input = False
+    current_settings.gui_settings.disable_config_auto_save = False
+    monkeypatch.setattr(gui, "settings", current_settings)
+
+    gui._save_gui_language_settings("zh")
+
+    assert len(captured_settings) == 1
+    assert captured_settings[0].gui_settings.ui_lang == "zh"
+    assert captured_settings[0].gui_settings.server_port == 7860
+    assert captured_settings[0].gui_settings.share is False
+    assert captured_settings[0].gui_settings.auth_file is None
+    assert captured_settings[0].gui_settings.welcome_page == "snapshot-welcome.md"
+    assert captured_settings[0].gui_settings.disable_gui_sensitive_input is True
+    assert captured_settings[0].gui_settings.disable_config_auto_save is True
+    assert gui.settings.gui_settings.ui_lang == "zh"
+    assert gui.settings.gui_settings.server_port == 9999
+    assert gui.settings.gui_settings.share is True
+    assert gui.settings.gui_settings.auth_file == str(tmp_path / "runtime-auth.csv")
+    assert gui.settings.gui_settings.welcome_page == "runtime-welcome.md"
+    assert gui.settings.gui_settings.disable_gui_sensitive_input is False
+    assert gui.settings.gui_settings.disable_config_auto_save is False
+
+
+def test_gui_language_save_no_config_snapshot_does_not_crash(monkeypatch):
+    gui = _gui(monkeypatch)
+    captured_settings = []
+
+    def capture_user_config(settings):
+        captured_settings.append(settings.clone())
+
+    monkeypatch.setattr(
+        gui.config_manager,
+        "write_user_default_config_file",
+        capture_user_config,
+    )
+    def ignore_language_update(_lang):
+        return None
+
+    monkeypatch.setattr(gui, "update_current_languages", ignore_language_update)
+    monkeypatch.setattr(gui.config_manager, "config_cli_settings", None)
+
+    current_settings = CLIEnvSettingsModel()
+    current_settings.gui_settings.server_port = 9999
+    current_settings.gui_settings.share = True
+    monkeypatch.setattr(gui, "settings", current_settings)
+
+    gui._save_gui_language_settings("zh")
+
+    assert len(captured_settings) == 1
+    assert captured_settings[0].gui_settings.ui_lang == "zh"
+    assert captured_settings[0].gui_settings.server_port != 9999
+    assert captured_settings[0].gui_settings.share is False
+    assert gui.settings.gui_settings.ui_lang == "zh"
+    assert gui.settings.gui_settings.server_port == 9999
+    assert gui.settings.gui_settings.share is True


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes two GUI issues: saving settings no longer resets the UI language, and Enhanced Compatibility now correctly forces related PDF options.

- **Bug Fixes**
  - Persist only `ui_lang`; keep `share`, `auth_file`, and `server_port` from the startup snapshot or safe defaults.
  - Use a safe persisted copy for saves; the language selector uses the same path. Tests cover all save modes, auto-save off, and no-snapshot cases.
  - Enhanced Compatibility forces `skip_clean`, `disable_rich_text_translate`, and `dual_translate_first` on toggle, initial load, and config reload.

<sup>Written for commit 67b2209343d0ccfd51f2d4849ce76b639a234f4c. Summary will update on new commits. <a href="https://cubic.dev/pr/PDFMathTranslate-next/PDFMathTranslate-next/pull/339?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

