### PR TITLE
feat(gui): allow customise server name (bind address)

### DIFF
--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -75,6 +75,7 @@ class GUISettings(BaseModel):
     disable_config_auto_save: bool = Field(
         default=False, description="Disable automatic saving of configuration"
     )
+    server_name: str = Field(default="0.0.0.0", description="WebUI host") # noqa: S104
     server_port: int = Field(default=7860, description="WebUI port")
     ui_lang: str | None = Field(default="en", description="UI language")
 

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -4358,6 +4358,7 @@ def setup_gui(
     share: bool = False,
     auth_file: str | None = None,
     welcome_page: str | None = None,
+    server_name: str = "0.0.0.0",
     server_port=7860,
     inbrowser: bool = True,
 ) -> None:
@@ -4367,6 +4368,7 @@ def setup_gui(
     Inputs:
         - share: Whether to share the GUI
         - auth_file: The authentication file
+        - server_name: The host to run the server on
         - server_port: The port to run the server on
 
     Returns:
@@ -4381,7 +4383,7 @@ def setup_gui(
     if not auth_file or not user_list:
         try:
             demo.launch(
-                server_name="0.0.0.0",
+                server_name=server_name,
                 debug=True,
                 inbrowser=inbrowser,
                 share=share,
@@ -4390,7 +4392,7 @@ def setup_gui(
             )
         except Exception:
             print(
-                "Error launching GUI using 0.0.0.0.\nThis may be caused by global mode of proxy software."
+                f"Error launching GUI using {server_name}.\nThis may be caused by global mode of proxy software."
             )
             try:
                 demo.launch(
@@ -4415,7 +4417,7 @@ def setup_gui(
     else:
         try:
             demo.launch(
-                server_name="0.0.0.0",
+                server_name=server_name,
                 debug=True,
                 inbrowser=inbrowser,
                 share=share,
@@ -4426,7 +4428,7 @@ def setup_gui(
             )
         except Exception:
             print(
-                "Error launching GUI using 0.0.0.0.\nThis may be caused by global mode of proxy software."
+                f"Error launching GUI using {server_name}.\nThis may be caused by global mode of proxy software."
             )
             try:
                 demo.launch(

--- a/pdf2zh_next/main.py
+++ b/pdf2zh_next/main.py
@@ -94,6 +94,7 @@ async def main() -> int:
         setup_gui(
             auth_file=settings.gui_settings.auth_file,
             welcome_page=settings.gui_settings.welcome_page,
+            server_name=settings.gui_settings.server_name,
             server_port=settings.gui_settings.server_port,
         )
         return 0

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -46,6 +46,13 @@ class TestBuildArgsParser:
         assert "basic" in field_name2type
         assert "translation" in field_name2type
 
+    def test_server_name_is_explicit_cli_value(self):
+        parser, _ = build_args_parser()
+
+        args = parser.parse_args(["--server-name", "127.0.0.1"])
+
+        assert args.server_name == "127.0.0.1"
+
     def test_deepseek_thinking_mode_is_explicit_cli_value(self):
         """Test DeepSeek thinking mode can be selected from CLI."""
         parser, _ = build_args_parser()
@@ -80,6 +87,7 @@ class TestBuildArgsParser:
         assert args.deepseek is True
         assert args.deepseek_thinking_mode is MagicDefault
 
+
 class TestConfigManager:
     def test_singleton(self):
         """Test ConfigManager singleton pattern"""
@@ -107,6 +115,13 @@ class TestConfigManager:
         assert env_settings["report_interval"] == 0.5
         assert env_settings["translation"]["qps"] == 10
         assert "invalid_key" not in env_settings
+
+    def test_server_name_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("PDF2ZH_SERVER_NAME", "127.0.0.1")
+
+        env_settings = ConfigManager().parse_env_vars()
+
+        assert env_settings["gui_settings"]["server_name"] == "127.0.0.1"
 
     def test_convert_env_value(self):
         """Test environment variable value conversion"""


### PR DESCRIPTION
The GUI server currently run under `0.0.0.0` and is hardcoded, which is an unsafe behaviour. This PR allows user to customise their server name like `127.0.0.1` for better network isolation. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the GUI bind address configurable so users can run the server on `127.0.0.1` (or any host) instead of always `0.0.0.0`. This improves network isolation while keeping `0.0.0.0` as the default.

- **New Features**
  - Added `gui_settings.server_name` (default `0.0.0.0`).
  - `setup_gui(..., server_name=...)` forwards the host to the launcher and updates error messages.
  - Supports `--server-name` and `PDF2ZH_SERVER_NAME`; `main` passes the value to the GUI; tests cover CLI and env parsing.

<sup>Written for commit a1d4fb9c76ea8f1ce5fd62313e33d24cd14f1e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/PDFMathTranslate-next/PDFMathTranslate-next/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

